### PR TITLE
downgrade minimum Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/caddyserver/zerossl
 
-go 1.22.0
+go 1.21.0


### PR DESCRIPTION
The `go` directive is set to the current version on the system where the module was created. It defines the minimum accepted version of Go to set the language semantics. This dep forced certmagic minimum Go to increase to 1.22, which cascaded to Caddy requiring Go 1.22. None of them require the upgrade. Using lower version in this line does not block building with newer Go versions. It does cause pain in building, as reported on various modules trying to use the `builder` variant of the Caddy docker image. 

It's best to keep this at 1.21 for now, until the new Docker images have the newer version of Go, then we can move this value up (if important).