### PR TITLE
fixed revokeCertificate  get==>post

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -201,7 +201,7 @@ func (c Client) RevokeCertificate(ctx context.Context, certificateID string, rea
 	var result struct {
 		Success anyBool `json:"success"`
 	}
-	if err := c.httpPost(ctx, endpoint, qs, &result); err != nil {
+	if err := c.httpPost(ctx, endpoint, qs, nil,&result); err != nil {
 		return err
 	}
 

--- a/endpoints.go
+++ b/endpoints.go
@@ -201,7 +201,7 @@ func (c Client) RevokeCertificate(ctx context.Context, certificateID string, rea
 	var result struct {
 		Success anyBool `json:"success"`
 	}
-	if err := c.httpGet(ctx, endpoint, qs, &result); err != nil {
+	if err := c.httpPost(ctx, endpoint, qs, &result); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The Revoke Certificate method specified in the zerossl api document is a post request.